### PR TITLE
Add lunch wheel web app with admin management

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,47 +1,183 @@
-from flask import Flask, request, jsonify
-from twilio.twiml.messaging_response import MessagingResponse
-import subprocess
+from __future__ import annotations
+
+import json
+import os
+import random
+from dataclasses import dataclass
+from typing import Dict, List
+
+from flask import Flask, jsonify, redirect, render_template, request, session, url_for
+
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), "data", "options.json")
+DEFAULT_TOWN = "Marion, IL"
+
+
+@dataclass
+class Option:
+    name: str
+    category: str
+    ownership: str
+
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "dev-secret-key")
+
+
+def load_data() -> Dict[str, List[Dict[str, str]]]:
+    if not os.path.exists(DATA_FILE):
+        os.makedirs(os.path.dirname(DATA_FILE), exist_ok=True)
+        seed_data = {
+            "towns": {
+                DEFAULT_TOWN: [
+                    {"name": "Walt's", "category": "Sit Down", "ownership": "Locally Owned"},
+                    {"name": "17th Street Bar & Grill", "category": "Sit Down", "ownership": "Locally Owned"},
+                    {"name": "El Torito", "category": "Sit Down", "ownership": "Locally Owned"},
+                    {"name": "Pookie's Beer, Burgers & Bocce", "category": "Sit Down", "ownership": "Locally Owned"},
+                    {"name": "Culver's", "category": "Fast Food", "ownership": "Chain"},
+                    {"name": "Chick-fil-A", "category": "Fast Food", "ownership": "Chain"},
+                    {"name": "Taco Bell", "category": "Fast Food", "ownership": "Chain"},
+                    {"name": "Taqueria Los Tres Caminos (Food Truck)", "category": "Food Truck", "ownership": "Locally Owned"},
+                    {"name": "Smokehouse 155 Food Truck", "category": "Food Truck", "ownership": "Locally Owned"},
+                ]
+            }
+        }
+        with open(DATA_FILE, "w", encoding="utf-8") as handle:
+            json.dump(seed_data, handle, indent=2)
+    with open(DATA_FILE, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_data(data: Dict[str, List[Dict[str, str]]]) -> None:
+    with open(DATA_FILE, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+
+
+def get_town_options(town: str) -> List[Dict[str, str]]:
+    data = load_data()
+    return data.get("towns", {}).get(town, [])
+
+
+def require_admin() -> bool:
+    return session.get("is_admin", False)
+
 
 @app.route("/")
-def home():
-    return jsonify({"message": "✅ ProTek Chatbot is running. I hope this works!"})
+def index():
+    data = load_data()
+    towns = sorted(data.get("towns", {}).keys())
+    return render_template("index.html", default_town=DEFAULT_TOWN, towns=towns)
 
-@app.route("/git-pull", methods=["POST"])
-def git_pull():
-    try:
-        result = subprocess.run(["git", "pull"], capture_output=True, text=True, cwd="/opt/protek-chatbot")
-        output = result.stdout.strip()
-        error_output = result.stderr.strip()
 
-        def restart_service():
-            subprocess.run(["sudo", "systemctl", "restart", "protek-chatbot"])
+@app.route("/api/towns")
+def towns():
+    data = load_data()
+    return jsonify({"towns": sorted(data.get("towns", {}).keys())})
 
-        threading.Thread(target=restart_service).start()
 
-        return jsonify({
-            "output": output or error_output,
-            "status": "success"
-        }), 200
+@app.route("/api/options")
+def options():
+    town = request.args.get("town", DEFAULT_TOWN)
+    options_list = get_town_options(town)
+    return jsonify({"town": town, "options": options_list})
 
-    except Exception as e:
-        return jsonify({"output": str(e), "status": "error"}), 500
 
-@app.route("/sms", methods=["POST"])
-def sms_reply():
-    incoming_msg = request.form.get("Body", "").strip().lower()
-    resp = MessagingResponse()
+@app.route("/api/spin", methods=["POST"])
+def spin():
+    payload = request.get_json(silent=True) or {}
+    town = payload.get("town", DEFAULT_TOWN)
+    category = payload.get("category", "All")
+    ownership = payload.get("ownership", "All")
 
-    # Basic logic example
-    if "hi" in incoming_msg or "hello" in incoming_msg:
-        resp.message("👋 Hello! This is the ProTek Chatbot. How can I help you today?")
-    elif "help" in incoming_msg:
-        resp.message("🛠️ Sure! You can ask me about your service, report an outage, or check your account.")
-    else:
-        resp.message("🤖 Sorry, I didn’t understand that. Try saying 'help' or 'hello'.")
+    options_list = get_town_options(town)
+    filtered = [
+        option
+        for option in options_list
+        if (category == "All" or option["category"] == category)
+        and (ownership == "All" or option["ownership"] == ownership)
+    ]
 
-    return str(resp)
+    if not filtered:
+        return jsonify({"error": "No matches for those filters."}), 404
+
+    chosen = random.choice(filtered)
+    return jsonify({"result": chosen})
+
+
+@app.route("/admin", methods=["GET", "POST"])
+def admin_login():
+    if request.method == "POST":
+        password = request.form.get("password", "")
+        admin_password = os.environ.get("ADMIN_PASSWORD", "admin123")
+        if password == admin_password:
+            session["is_admin"] = True
+            return redirect(url_for("admin_panel"))
+        return render_template("login.html", error="Invalid password")
+
+    return render_template("login.html", error=None)
+
+
+@app.route("/admin/logout")
+def admin_logout():
+    session.pop("is_admin", None)
+    return redirect(url_for("index"))
+
+
+@app.route("/admin/panel")
+def admin_panel():
+    if not require_admin():
+        return redirect(url_for("admin_login"))
+
+    data = load_data()
+    towns = sorted(data.get("towns", {}).keys())
+    selected_town = request.args.get("town", DEFAULT_TOWN)
+    options_list = data.get("towns", {}).get(selected_town, [])
+    return render_template(
+        "admin.html",
+        towns=towns,
+        selected_town=selected_town,
+        options_list=options_list,
+    )
+
+
+@app.route("/admin/options", methods=["POST"])
+def admin_options():
+    if not require_admin():
+        return redirect(url_for("admin_login"))
+
+    data = load_data()
+    town = request.form.get("town", DEFAULT_TOWN).strip()
+    action = request.form.get("action")
+
+    towns_data = data.setdefault("towns", {})
+    towns_data.setdefault(town, [])
+
+    if action == "add":
+        name = request.form.get("name", "").strip()
+        category = request.form.get("category", "Sit Down")
+        ownership = request.form.get("ownership", "Locally Owned")
+        if name:
+            towns_data[town].append(
+                {"name": name, "category": category, "ownership": ownership}
+            )
+    elif action == "delete":
+        index = int(request.form.get("index", "-1"))
+        if 0 <= index < len(towns_data[town]):
+            towns_data[town].pop(index)
+    elif action == "update":
+        index = int(request.form.get("index", "-1"))
+        name = request.form.get("name", "").strip()
+        category = request.form.get("category", "Sit Down")
+        ownership = request.form.get("ownership", "Locally Owned")
+        if 0 <= index < len(towns_data[town]) and name:
+            towns_data[town][index] = {
+                "name": name,
+                "category": category,
+                "ownership": ownership,
+            }
+
+    save_data(data)
+    return redirect(url_for("admin_panel", town=town))
 
 
 if __name__ == "__main__":

--- a/data/options.json
+++ b/data/options.json
@@ -1,0 +1,51 @@
+{
+  "towns": {
+    "Marion, IL": [
+      {
+        "name": "Walt's",
+        "category": "Sit Down",
+        "ownership": "Locally Owned"
+      },
+      {
+        "name": "17th Street Bar & Grill",
+        "category": "Sit Down",
+        "ownership": "Locally Owned"
+      },
+      {
+        "name": "El Torito",
+        "category": "Sit Down",
+        "ownership": "Locally Owned"
+      },
+      {
+        "name": "Pookie's Beer, Burgers & Bocce",
+        "category": "Sit Down",
+        "ownership": "Locally Owned"
+      },
+      {
+        "name": "Culver's",
+        "category": "Fast Food",
+        "ownership": "Chain"
+      },
+      {
+        "name": "Chick-fil-A",
+        "category": "Fast Food",
+        "ownership": "Chain"
+      },
+      {
+        "name": "Taco Bell",
+        "category": "Fast Food",
+        "ownership": "Chain"
+      },
+      {
+        "name": "Taqueria Los Tres Caminos (Food Truck)",
+        "category": "Food Truck",
+        "ownership": "Locally Owned"
+      },
+      {
+        "name": "Smokehouse 155 Food Truck",
+        "category": "Food Truck",
+        "ownership": "Locally Owned"
+      }
+    ]
+  }
+}

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,144 @@
+const townInput = document.getElementById("town");
+const townStatus = document.getElementById("town-status");
+const loadTownButton = document.getElementById("load-town");
+const categorySlider = document.getElementById("category-slider");
+const ownershipSlider = document.getElementById("ownership-slider");
+const categoryValue = document.getElementById("category-value");
+const ownershipValue = document.getElementById("ownership-value");
+const spinButton = document.getElementById("spin");
+const resultEl = document.getElementById("result");
+const optionsList = document.getElementById("options-list");
+const wheelCanvas = document.getElementById("wheel");
+const ctx = wheelCanvas.getContext("2d");
+
+const categoryMap = ["Fast Food", "Sit Down", "Food Truck", "All"];
+const ownershipMap = ["Locally Owned", "Chain", "All"];
+let currentOptions = [];
+let currentRotation = 0;
+
+function updateSliderLabels() {
+  categoryValue.textContent = categoryMap[Number(categorySlider.value)];
+  ownershipValue.textContent = ownershipMap[Number(ownershipSlider.value)];
+}
+
+function drawWheel() {
+  const options = currentOptions.length ? currentOptions : [{ name: "Add options" }];
+  const radius = wheelCanvas.width / 2;
+  ctx.clearRect(0, 0, wheelCanvas.width, wheelCanvas.height);
+  ctx.save();
+  ctx.translate(radius, radius);
+  ctx.rotate(currentRotation);
+
+  const sliceAngle = (Math.PI * 2) / options.length;
+  options.forEach((option, index) => {
+    ctx.beginPath();
+    ctx.fillStyle = index % 2 === 0 ? "#93c5fd" : "#dbeafe";
+    ctx.moveTo(0, 0);
+    ctx.arc(0, 0, radius - 10, sliceAngle * index, sliceAngle * (index + 1));
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.save();
+    ctx.rotate(sliceAngle * index + sliceAngle / 2);
+    ctx.textAlign = "right";
+    ctx.fillStyle = "#1e293b";
+    ctx.font = "bold 14px sans-serif";
+    ctx.fillText(option.name, radius - 24, 8);
+    ctx.restore();
+  });
+
+  ctx.restore();
+}
+
+function renderOptions() {
+  optionsList.innerHTML = "";
+  if (!currentOptions.length) {
+    const li = document.createElement("li");
+    li.textContent = "No options found for this town yet.";
+    optionsList.appendChild(li);
+    drawWheel();
+    return;
+  }
+
+  currentOptions.forEach((option) => {
+    const li = document.createElement("li");
+    li.textContent = `${option.name} · ${option.category} · ${option.ownership}`;
+    optionsList.appendChild(li);
+  });
+  drawWheel();
+}
+
+async function loadTown() {
+  const town = townInput.value.trim();
+  if (!town) {
+    return;
+  }
+  townStatus.textContent = "Loading...";
+  const response = await fetch(`/api/options?town=${encodeURIComponent(town)}`);
+  const data = await response.json();
+  currentOptions = data.options || [];
+  renderOptions();
+  townStatus.textContent = currentOptions.length
+    ? `Loaded ${currentOptions.length} options for ${data.town}.`
+    : `No saved options for ${data.town} yet.`;
+}
+
+async function spinWheel() {
+  const town = townInput.value.trim();
+  if (!town) {
+    return;
+  }
+
+  const payload = {
+    town,
+    category: categoryMap[Number(categorySlider.value)],
+    ownership: ownershipMap[Number(ownershipSlider.value)],
+  };
+
+  const response = await fetch("/api/spin", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    resultEl.textContent = "No matches for those filters.";
+    return;
+  }
+
+  const data = await response.json();
+  const chosen = data.result;
+  resultEl.textContent = `You should try: ${chosen.name}`;
+
+  const options = currentOptions.length ? currentOptions : [chosen];
+  const chosenIndex = options.findIndex((option) => option.name === chosen.name);
+  const sliceAngle = (Math.PI * 2) / options.length;
+  const rotations = 6;
+  const targetAngle = (options.length - chosenIndex) * sliceAngle;
+
+  const start = currentRotation;
+  const end = rotations * Math.PI * 2 + targetAngle;
+  const duration = 1600;
+  const startTime = performance.now();
+
+  function animate(now) {
+    const elapsed = now - startTime;
+    const progress = Math.min(elapsed / duration, 1);
+    const eased = 1 - Math.pow(1 - progress, 3);
+    currentRotation = start + (end - start) * eased;
+    drawWheel();
+    if (progress < 1) {
+      requestAnimationFrame(animate);
+    }
+  }
+
+  requestAnimationFrame(animate);
+}
+
+categorySlider.addEventListener("input", updateSliderLabels);
+ownershipSlider.addEventListener("input", updateSliderLabels);
+loadTownButton.addEventListener("click", loadTown);
+spinButton.addEventListener("click", spinWheel);
+
+updateSliderLabels();
+loadTown();

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,253 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, sans-serif;
+  --primary: #2563eb;
+  --background: #f8fafc;
+  --card: #ffffff;
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --danger: #dc2626;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 40px;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0;
+}
+
+header p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+main {
+  padding: 32px 40px 64px;
+}
+
+.controls {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-bottom: 32px;
+}
+
+.control-group {
+  background: var(--card);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.control-group label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.control-group input[type="text"],
+.control-group input[type="password"],
+.control-group select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.control-group button,
+button.primary {
+  margin-top: 12px;
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.slider-wrapper {
+  display: grid;
+  gap: 12px;
+}
+
+.slider-labels {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  font-size: 12px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.slider-labels span {
+  padding-top: 4px;
+}
+
+.slider-value {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.wheel-section {
+  text-align: center;
+}
+
+.wheel-container {
+  position: relative;
+  width: 420px;
+  margin: 0 auto 24px;
+}
+
+#wheel {
+  border-radius: 50%;
+  border: 10px solid var(--card);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
+  background: white;
+}
+
+.pointer {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 14px solid transparent;
+  border-right: 14px solid transparent;
+  border-bottom: 24px solid var(--primary);
+}
+
+.result {
+  margin-top: 16px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.options-section {
+  margin-top: 32px;
+}
+
+.options-section ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.options-section li {
+  background: var(--card);
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+.status {
+  display: block;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.admin-link {
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--primary);
+  color: white;
+}
+
+.auth {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.card {
+  background: var(--card);
+  padding: 32px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  width: min(360px, 90vw);
+}
+
+.card form {
+  display: grid;
+  gap: 12px;
+}
+
+.error {
+  color: var(--danger);
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.admin-table input,
+.admin-table select {
+  width: 100%;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.admin-table .actions {
+  display: flex;
+  gap: 8px;
+}
+
+.admin-form {
+  display: grid;
+  gap: 12px;
+  max-width: 480px;
+}
+
+button.danger {
+  background: var(--danger);
+  color: white;
+}
+
+@media (max-width: 600px) {
+  header,
+  main {
+    padding: 20px;
+  }
+
+  .wheel-container {
+    width: 320px;
+  }
+
+  #wheel {
+    width: 320px;
+    height: 320px;
+  }
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Panel</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <h1>Admin Panel</h1>
+      <p>Manage lunch options by town.</p>
+    </div>
+    <div class="header-actions">
+      <a class="admin-link" href="{{ url_for('admin_logout') }}">Logout</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="controls">
+      <form class="admin-form" method="get" action="{{ url_for('admin_panel') }}">
+        <label for="town">Town</label>
+        <input id="town" name="town" type="text" list="town-list" value="{{ selected_town }}">
+        <datalist id="town-list">
+          {% for town in towns %}
+          <option value="{{ town }}"></option>
+          {% endfor %}
+        </datalist>
+        <button type="submit">Load</button>
+      </form>
+    </section>
+
+    <section class="options-section">
+      <h2>Options for {{ selected_town }}</h2>
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Category</th>
+            <th>Ownership</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for option in options_list %}
+          <tr>
+            <form method="post" action="{{ url_for('admin_options') }}">
+              <td>
+                <input type="text" name="name" value="{{ option.name }}" required>
+              </td>
+              <td>
+                <select name="category">
+                  {% for category in ['Fast Food', 'Sit Down', 'Food Truck'] %}
+                  <option value="{{ category }}" {% if option.category == category %}selected{% endif %}>{{ category }}</option>
+                  {% endfor %}
+                </select>
+              </td>
+              <td>
+                <select name="ownership">
+                  {% for owner in ['Locally Owned', 'Chain'] %}
+                  <option value="{{ owner }}" {% if option.ownership == owner %}selected{% endif %}>{{ owner }}</option>
+                  {% endfor %}
+                </select>
+              </td>
+              <td class="actions">
+                <input type="hidden" name="town" value="{{ selected_town }}">
+                <input type="hidden" name="index" value="{{ loop.index0 }}">
+                <button type="submit" name="action" value="update">Update</button>
+                <button type="submit" name="action" value="delete" class="danger">Delete</button>
+              </td>
+            </form>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="4">No options yet. Add one below.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+
+    <section class="options-section">
+      <h2>Add a new option</h2>
+      <form class="admin-form" method="post" action="{{ url_for('admin_options') }}">
+        <input type="hidden" name="town" value="{{ selected_town }}">
+        <label for="name">Name</label>
+        <input id="name" name="name" type="text" required>
+        <label for="category">Category</label>
+        <select id="category" name="category">
+          <option value="Fast Food">Fast Food</option>
+          <option value="Sit Down" selected>Sit Down</option>
+          <option value="Food Truck">Food Truck</option>
+        </select>
+        <label for="ownership">Ownership</label>
+        <select id="ownership" name="ownership">
+          <option value="Locally Owned" selected>Locally Owned</option>
+          <option value="Chain">Chain</option>
+        </select>
+        <button type="submit" name="action" value="add" class="primary">Add option</button>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Marion Lunch Spinner</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <h1>Lunch Wheel</h1>
+      <p>Spin the wheel to pick your next spot in Marion, IL (or your town).</p>
+    </div>
+    <div class="header-actions">
+      <a class="admin-link" href="{{ url_for('admin_login') }}">Admin</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="controls">
+      <div class="control-group">
+        <label for="town">Your town</label>
+        <input id="town" name="town" type="text" list="town-list" value="{{ default_town }}">
+        <datalist id="town-list">
+          {% for town in towns %}
+          <option value="{{ town }}"></option>
+          {% endfor %}
+        </datalist>
+        <button id="load-town" type="button">Load town list</button>
+        <span id="town-status" class="status"></span>
+      </div>
+
+      <div class="control-group">
+        <label>Meal type</label>
+        <div class="slider-wrapper">
+          <input id="category-slider" type="range" min="0" max="3" step="1" value="3">
+          <div class="slider-labels">
+            <span>Fast Food</span>
+            <span>Sit Down</span>
+            <span>Food Truck</span>
+            <span>All</span>
+          </div>
+          <p class="slider-value">Selected: <strong id="category-value">All</strong></p>
+        </div>
+      </div>
+
+      <div class="control-group">
+        <label>Ownership</label>
+        <div class="slider-wrapper">
+          <input id="ownership-slider" type="range" min="0" max="2" step="1" value="2">
+          <div class="slider-labels">
+            <span>Locally Owned</span>
+            <span>Chain</span>
+            <span>All</span>
+          </div>
+          <p class="slider-value">Selected: <strong id="ownership-value">All</strong></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="wheel-section">
+      <div class="wheel-container">
+        <canvas id="wheel" width="420" height="420"></canvas>
+        <div class="pointer"></div>
+      </div>
+      <button id="spin" class="primary">Spin the wheel</button>
+      <div id="result" class="result"></div>
+    </section>
+
+    <section class="options-section">
+      <h2>Current options</h2>
+      <ul id="options-list"></ul>
+    </section>
+  </main>
+
+  <script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Login</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <main class="auth">
+    <div class="card">
+      <h1>Admin Login</h1>
+      <p>Enter the admin password to manage lunch options.</p>
+      <form method="post">
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" required>
+        {% if error %}
+        <p class="error">{{ error }}</p>
+        {% endif %}
+        <button type="submit" class="primary">Login</button>
+      </form>
+      <a href="{{ url_for('index') }}">Back to wheel</a>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace the previous placeholder Flask service with a small interactive app to let users spin a wheel to pick lunch options and to let an admin manage the list.
- Provide quick local seeding for Marion, IL so the app is usable out-of-the-box and allow selecting other towns via a town input.
- Support filter controls (meal type and ownership) and a simple backend that persists changes for immediate local use.

### Description
- Replace `app.py` with a Flask app that exposes the UI route and API endpoints (`/`, `/api/towns`, `/api/options`, `/api/spin`) and admin routes (`/admin`, `/admin/panel`, `/admin/options`) with session-based admin login controlled by the `ADMIN_PASSWORD` environment variable.
- Add a JSON-backed datastore at `data/options.json` seeded with several Marion, IL restaurants and helper functions `load_data`, `save_data`, and `get_town_options` to read/write options.
- Add templates (`templates/index.html`, `templates/login.html`, `templates/admin.html`) and static assets (`static/styles.css`, `static/app.js`) implementing the wheel UI, filter sliders, town input, admin CRUD forms, and client-side wheel drawing/animation and API integration.
- Persist admin CRUD operations (add/update/delete) to the JSON file and keep sensible defaults (`DEFAULT_TOWN = "Marion, IL"` and `FLASK_SECRET_KEY`/`ADMIN_PASSWORD` fallbacks) for local development.

### Testing
- Installed required dependency with `pip install flask` and successfully started the app with `python app.py` which served on `http://127.0.0.1:5000`.
- Exercised the UI via an automated Playwright script which loaded the page and produced a screenshot artifact `artifacts/lunch-wheel.png`, confirming static assets were served.
- Verified the API call `GET /api/options?town=Marion,%20IL` returned the seeded options and the `data/options.json` file was created and contains the seed entries.
- Confirmed the server logged requests for `/`, `/static/styles.css`, `/static/app.js` and `/api/options` during the test run and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a39ed75908327a533a38770426e8c)